### PR TITLE
Limit the automatic deployment to node v6 only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ deploy:
   script: npm run deploy:prod -- --token ${FIREBASE_TOKEN}
   on:
     branch: master
+    node: "6"
 language: node_js
 node_js:
   - "node"


### PR DESCRIPTION
Make sure the deployment to production only happens on the node 6 target. This prevents a deployment for each node version the tests execute for.